### PR TITLE
fix: include port in URL parsing for package info and tarball fetching

### DIFF
--- a/modules/utils/npm.js
+++ b/modules/utils/npm.js
@@ -70,10 +70,11 @@ async function fetchPackageInfo(packageName, log) {
 
   log.debug('Fetching package info for %s from %s', packageName, infoURL);
 
-  const { hostname, pathname } = url.parse(infoURL);
+  const { hostname, pathname, port } = url.parse(infoURL);
   const options = {
     agent: agent,
     hostname: hostname,
+    port,
     path: pathname,
     headers: {
       Accept: 'application/json'
@@ -202,10 +203,11 @@ export async function getPackage(packageName, version, log) {
 
   log.debug('Fetching package for %s from %s', packageName, tarballURL);
 
-  const { hostname, pathname } = url.parse(tarballURL);
+  const { hostname, pathname, port } = url.parse(tarballURL);
   const options = {
     agent: agent,
     hostname: hostname,
+    port,
     path: pathname
   };
 


### PR DESCRIPTION
This pull request includes changes to the `modules/utils/npm.js` file to enhance the URL parsing functionality for fetching package information and package tarballs. The main updates involve including the `port` in the parsed URL components.

Enhancements to URL parsing:

* [`modules/utils/npm.js`](diffhunk://#diff-2c685634aabe1a84c0fd8b0823f6da812e5d3a4c1bed9e6e4410ddeb634ec028L73-R77): Updated the `fetchPackageInfo` function to include the `port` when parsing the `infoURL`.
* [`modules/utils/npm.js`](diffhunk://#diff-2c685634aabe1a84c0fd8b0823f6da812e5d3a4c1bed9e6e4410ddeb634ec028L205-R210): Updated the `getPackage` function to include the `port` when parsing the `tarballURL`.